### PR TITLE
Throw correct error if #parse! is called with an invalid sentence.

### DIFF
--- a/lib/range_sentence_parser.rb
+++ b/lib/range_sentence_parser.rb
@@ -1,3 +1,4 @@
+require 'range_sentence_parser/invalid_sentence_error'
 require 'range_sentence_validator' if defined? ActiveModel
 
 class RangeSentenceParser


### PR DESCRIPTION
Before:

```
>> require 'range_sentence_parser'
=> true
>> RangeSentenceParser.parse!("foo")
NameError: uninitialized constant RangeSentenceParser::InvalidSentenceError
        from /Users/bernardes/.rvm/gems/ruby-1.9.3-p194/gems/range_sentence_parser-0.0.2/lib/range_sentence_parser.rb:45:in `parse!'
        from /Users/bernardes/.rvm/gems/ruby-1.9.3-p194/gems/range_sentence_parser-0.0.2/lib/range_sentence_parser.rb:15:in `parse!'
        from (irb):2
        from /Users/bernardes/.rvm/rubies/ruby-1.9.3-p194/bin/irb:16:in `<main>'
```

After:

```
>> require 'lib/range_sentence_parser'
=> true
>> RangeSentenceParser.parse!("foo")
RangeSentenceParser::InvalidSentenceError: RangeSentenceParser::InvalidSentenceError
        from /Users/bernardes/projetos/nohup/range_sentence_parser/lib/range_sentence_parser.rb:46:in `parse!'
        from /Users/bernardes/projetos/nohup/range_sentence_parser/lib/range_sentence_parser.rb:16:in `parse!'
        from (irb):2
        from /Users/bernardes/.rvm/rubies/ruby-1.9.3-p194/bin/irb:16:in `<main>'
```
